### PR TITLE
fix(ep94): 21 → HUSZONEGY + markdown támogatás előkészítés

### DIFF
--- a/public/transcripts_clean/epE94_gt9eFE_4KvQ.txt
+++ b/public/transcripts_clean/epE94_gt9eFE_4KvQ.txt
@@ -25,7 +25,7 @@ Fejlesztő vagy, fejleszted.
 Ha cég vagy, akkor elfogadod.
 Ha semmihez se értesz, akkor podcastot csinálsz.
 Sziasztok, üdvözlünk mindenkit.
-Ez itt a 21 Bitcoin podcast. 94. epizódja, ugye úgy gondolom.
+Ez itt a HUSZONEGY Bitcoin podcast. 94. epizódja, ugye úgy gondolom.
 És mai vendégünk Robi.
 Szia Robi!
 Üdvözöllek újra itt nálunk.
@@ -490,12 +490,12 @@ Nyilván mindenkiben benne van az, hogy elfelejt egy covidot, egy 2008-as váls�
 Közeleg a február 26-i budapesti Perspective Baros Meetup, ahol a személyes ismerkedés mellett egy gyakorlatias előadással készülünk a Ginger Walletről és a CoinJoin-ról.
 Kérjük, hogy a részvételi szándékot jelezzétek a bitcoinmentor.hu/meetup oldalon.
 A Telegram csoportunkban éppen szerveződik a következő győri meetup.
-Böngészétek a 21 honlapját a huszonegy.world címen, ahol rengeteg ingyenes oktatóanyag elérhető.
+Böngészétek a HUSZONEGY honlapját a huszonegy.world címen, ahol rengeteg ingyenes oktatóanyag elérhető.
 Azok számára pedig, akik a Bitcoin tanulási útjukon személyes támogatást igényelnek, szeretettel ajánljuk a Bitcoin mentor szolgáltatásait is.
 A bitcoinmentor.hu honlapon részletesen olvashatsz a Bitcoin tanácsadásunkról.
 A Bitcoin blogban pedig egyre több értékes bejegyzést találsz.
-Iratkozz fel a 21 podcast YouTube csatornájára, valamint a Rumble csatornánkra is.
-Kövesd a 21-et a Facebookon és a Nosteren.
+Iratkozz fel a HUSZONEGY podcast YouTube csatornájára, valamint a Rumble csatornánkra is.
+Kövesd a HUSZONEGY-et a Facebookon és a Nosteren.
 Támogatóink Miskolctapolca és Hajdúszoboszló bitcoint elfogadó és Bitcoint tartalékoló négycsillagos Wellness szállodái a Hotel Aurora és a Hotel Atlantis.
 És a Firefish üzeni, hogy ne adjátok el a bitcoinotokat.
 Robi, én megköszönöm, hogy itt voltál nálunk.


### PR DESCRIPTION
## Summary
- 4 helyen "21" → "HUSZONEGY" (ahol a podcast nevére utal)
- "21 millió" / "21. század" helyesen marad

## Test plan
- [ ] Ellenőrizni, hogy a podcast oldalon a szöveg helyesen jelenik meg

🤖 Generated with [Claude Code](https://claude.com/claude-code)