### PR TITLE
sitemap: paraméterezett útvonalak és redirectek kiszűrése

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -122,7 +122,12 @@ export default defineConfig({
   ssgOptions: {
     dirStyle: 'nested',
     includedRoutes(paths: any, _routes: any) {
-      const staticPaths = paths;
+      // Kiszűrjük a paraméterezett útvonalakat (pl. :slug, :pathMatch),
+      // a redirecteket (pl. /support), és a statikus fájl útvonalakat (pl. /books/)
+      const kizart = ['/support', '/books']
+      const staticPaths = (paths as string[]).filter(p =>
+        !p.includes(':') && !kizart.some(k => p === k || p.startsWith(k + '/'))
+      )
       const podcastPaths = podcasts.map(p => `/podcast/${slugify(p.name)}`);
       return [...staticPaths, ...podcastPaths];
     },


### PR DESCRIPTION
## Összefoglaló

A sitemap-ből kiszűri a nem valódi oldalakat:

- **Paraméterezett útvonalak** (`:slug`, `:pathMatch(…)`) — ezek Vue Router minták, nem tényleges oldalak
- **`/support` redirect** — csak átirányít a `/tamogatas`-ra, duplikáció lenne a sitemap-ben
- **`/books/` statikus fájlok** — a `public/` mappából közvetlenül szolgált fájlok, nem Vue útvonalak

## Tesztelés

- [ ] Build után a sitemap nem tartalmaz `:pathMatch(`, `:slug`, `/support`, `/books/` útvonalakat
- [ ] A meglévő oldalak (podcast, cikk, hír stb.) továbbra is szerepelnek a sitemap-ben

🤖 Generated with [Claude Code](https://claude.com/claude-code)