### PR TITLE
sitemap: sziller.eu statikus fájl kiszűrése

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -137,7 +137,7 @@ export default defineConfig({
 
       generateSitemap({
         hostname: 'https://huszonegy.world',
-        exclude: ['/404'],
+        exclude: ['/404', '/books/sziller.eu/_BitcoinrolAlaposan'],
         // Útvonal-szintű lastmod dátumok — csak a ténylegesen módosított oldalak
         // kapnak friss dátumot. Nem leképezett útvonalak lastmod nélkül maradnak.
         lastmod: lastmodMap,


### PR DESCRIPTION
## Összefoglaló

A `/books/sziller.eu/_BitcoinrolAlaposan` még mindig megjelent a sitemap-ben, mert az `includedRoutes` csak az SSG útvonalakat szűri — a `generateSitemap()` viszont a build kimenetből dolgozik, ahol a `public/` mappából másolt statikus fájlok is szerepelnek.

A javítás a `generateSitemap()` `exclude` listájába teszi ezt az útvonalat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)