### PR TITLE
E79 átirat szépítés: Bitcoin Miskolc konferencia összefoglaló

### DIFF
--- a/public/transcripts_clean/epE79_x2vWSakAF3Y.md
+++ b/public/transcripts_clean/epE79_x2vWSakAF3Y.md
@@ -1,0 +1,429 @@
+Sziasztok! Üdvözlünk titeket az életbe visszatérve itt a HUSZONEGY virtuális stúdiójából. Ez itt a HUSZONEGY Bitcoin podcast 79. epizódja vagy adása. Vendégünk nem is lehetne más, mint Feri, akinek köszönhetően ugye most hétvégén volt a Miskolcon a Bitcoin konferencia, a Bitcoin Miskolc. Úgyhogy üdvözlünk téged újra itt, és szeretném megkérdezni, hogy hogyan érezted a konferencián magad. Sziasztok srácok!
+
+– Helló!
+
+– Először is szeretném megköszönni mindenkinek, aki eljött. Szerintem nagyon jól éreztő magkat így összefoglalva, illetve az én nevemben azt tudom mondani, illetve a srácok, kollégáim nevében, hogy nagyon érdekes emberekkel találkoztunk, nagyon intelligens csapat volt ismét. Ez szerintem a többi más megszokott szakmai fórum és egyéb más konferenciáktól eltérően a Bitcoin közösség mindig ugyanezt a vibe-ot hozza.
+
+Szabadság iránti vágy, a kíváncsiság, egymás megértése, hallgatás, érvelés, beszélgetés, ez mind jelen volt ezen a hétvégén. Úgyhogy köszönöm szépen nektek. Nem biztos, hogy mindenkivel annyit tudtam beszélgetni, amennyit akartam volna. Sokan megtaláltatok, de nekem is csak az a 24 óra adatott meg, úgyhogy legközelebb majd találkozunk, de én nagyon jól éreztem magam, és hát egyből vissza kellett rázódjak természetesen a a ipari mindennapokba, de robogunk tovább, dolgozunk tovább a projektjeinken indületlenül, és megyünk előre a Bitcoin adaptációval.
+
+Nagyon jó új ötletek lettek a következő konferenciára és ugye az utolsó körbe, ahogy a körrel zártuk a konferenciát, ahogy nyitottuk is, összeültünk, megbeszéltük azt, hogy milyen témák lehetnének még a következő konferencián, és egyből megint izgalomba jöttünk. Fú, de jó, megint egy tök olyan konferenciát, olyan programot tudunk összerakni, megint egy kicsit fejlettebb, jobb és megint többet tudunk majd adni.
+
+Úgyhogy várjuk már a következő alkalmakat és a meupokat is természetesen.
+
+– Hát igen, köszönjük, hogy ez így megint megtörtént. Tényleg tök jó volt egy csomó emberrel beszélgetni, és valóban ez olyan, hogy az ember így várja, és és hiába mész egy nappal előbb, akkor se tudsz mindenkivel kimerítően beszélgetni, ugye? pedig próbálsz, vagyis hát igen, velem is ez volt.
+
+– Igen, azért elmélyült beszélgetések voltak, tehát ugye leültünk este is beszélgetni egy-egy ital mellett, és hát úgy úgy eltelik az este, tehát azért nem egy hónapot voltunk együtt, de rendkívül tartalmas volt. Egyébként feleségem, képzeljétek, ő már javasolta is, őt már meg is jósolta egy évvel ezelőtt, hogy hamarosan már kéne rendeznünk egy ilyen ilyen egyhetes tábort, ilyen bitcoin tábort valahol.
+
+– Nem hülyeség. Milyen jó lenne. Volt olyan résztvevő, aki jelezte is, hogy neki ez a része tetszett a legjobban, hogy a beszélgetés nem csak velünk előadókkal, hanem egyébként a többi résztvevővel is. Úgyhogy nem elvetemlő dolog egyébként, hogy esetleg egyszer egy bitcoin tábort is összehozzunk majd egy lupus csapatot. Megvan az előnye, nincs ilyen feszített tempó, lazultabb, mélyebb tud lenni a beszélgetés sok témába.
+
+Ja, mindenki. Én benne vagyok. Árpi, te hogy érezted meg?
+
+– Én nagyon jól. Köszönöm. Szerintem is remek volt a a társaság. Ugye nagyon jó volt látni, hogy visszatérő arcok is vannak már minket leszámítva, ugye a kikellve az előadásokat összerakjuk meg ilyesmi, meg amúgy is viszonylag rendszeresen találkozunk egymással. De ugye a konferencia résztvevői között volt több olyan figura, aki az előző konferencián is volt, vagy már a az elsőn, ami ugye egy évvel ezelőtt volt ugyanígy Miskolcon.
+
+Ugyanakkor meg tök jó volt. Igen, az is, hogy hogy új arcok, új impulzusok és rajtuk is látszott a lelkesedés. Meg nagyon szeretem azokat a visszajelzéseket, amiket így mondanak nekünk, hogy milyen sokat ad nekik az, hogy most már ilyen sok tartalom élhető el magyar nyelven, meg hogy az is van, az is van. És ez mindig olyan szívetmelengető, meg egy motiváló is, hogy akkor akkor lendületet ad a folytatáshoz.
+
+– Ja igen.
+
+– A tényleg jó.
+
+– Te hogy érzem magad?
+
+– Köszönjük.
+
+– Hú, én nagyon jól éreztem magam kicsit. Nyilván izgultam az ember nem tudom, én legalábbis én mindig így izgulok egy picit, hogy hogy mi lesz, meg ki lesz, ki ki ül ott majd. De aztán amikor láttam, hogy a azért nagyon sok embert ismerek így az előző platformokról, meg ugye hát titeket, meg egy csomó más HUSZONEGY-es arcot, így azért így így jobb volt persze, de de tényleg benne van az ember, ez a emberben ez a ez a druk, ez a vizsgadruk, hogy na
+
+– hm
+
+– milyen lesz a a közeg, ki lesz az, aki ott hallgatja, és mivel megy haza, hogy jön. Ezek tök jók. illetve az, amikor így napközben így így szünetekbe az ember így beleütközik valakibe, és jönnek a kérdések, hogy hogy én erről mit gondolok, hogy te erről mit gondolsz, meg mi a véleményed satöbbi, satöbbi. Ezek ilyen jól esők meg a biztató szavak, azok is tényleg nagyon-nagyon jól esnek. egyébként nagyon sok kezdő is volt, tehát ez teljesen jó volt látni, hogy utolérte az üzenet azokat az embereket, akik féltek eljönni, mert nekem több ilyen visszajelzésem volt, hogy hát én nem jövök felé, én nem értek annyira hozzá, én nem vagyok benne annyira.
+
+És akkor ezt rájöttem, hogy kicsit nem félre kommunikáltuk, csak alul kommunikáltuk azt a tényt, hogy alapvetően ez teljesen kezdő széttől indult ez a konferenciának a tananyaga, illetve hát az ismeret, amit átadtunk, nem is tananyag és jó volt látni, hogy teljesen új családok, csoportok, emberek kapcsolódtak be a Bitcoin közösségébe, és váltak teljesen lelkessé. átjött nekik az, amit tartottál Anti meg a többiek előadás is.
+
+Úgyhogy szerintem ez egy nagyon sikeres hétvége volt.
+
+– Nekem még az volt így nagyon jó érzés, és nem tudom, hogy nektek ez hogy jött le, hogy így legelőször nyilván az ember így nagyon örül, hogy van ilyen, másodszor örül, hogy így fejlődünk, de most harmadszor engem teljesen az a benyomás ért, hogy mindenki kezd ugyanazon az oldalon lenni, ahol mi. Tehát, hogy hogy valóban bitcoinerekkel találkozunk és és értik azt, ami amiről így dumálunk. Tehát, hogy valóban megtakarítanak benne, tehát nem nem hazárdíroznak.
+
+Persze nyilván van aki kereskedik, de hogy sokkal inkább kivehető volt a részemre ez a ez a megfontoltság így a ott a tömegben. Nem tudom, hogy ti ezt éreztétek-e. Nekem nagyon lejött. illetve én úgy gondolom, hogy sokkal bátrabbak vagyunk így előadók is abban, amit mondunk, tehát a mondanivalónkban is. Szerint nekem nekem így ez volt így, ami így így nagyon én is így gondolom közönség soraiból azért kevesebb kérdés jött arra irányulólag, hogy milyen ciklusban vagyunk, bika vagy bear marketet fog következni, vagy milyen tőzsei mozgások várhatók.
+
+Természetesen ez is felmerült, viszont szerintem a közönségnek átjött. az, hogy nálunk alapvetően tényleg a Bitcoin miatt vagyunk ott, és nem pedig az áfolyam miatt, és tényleg nagyon jó volt a közönség ilyen szempontból, hogy úgy ráérzette ennek az ízére, hogy miért miért jó a Bitcoin és hogy mire tudjuk használni.
+
+– Igen. Kíváncsi vagyok, hogy hogyan folytatják a lépéseket, mert azért el lettek látva útravalóval. Tehát
+
+– figyelj, tőlünk vettek 20 hardware valetet, úgyhogy bízunk benne, hogy hogy jól fogják használni. Ez is egy nagy eredmény, mert ugye eddig nem tudom milyennyi fogyott korábban, de de ez egy tök jó, hogy ilyen jó eszközökkel tudtak távozni az emberek, és hát 20 olyan embert találtunk akkor, akinek már saját kezében lesznek a kulcsai hamarosan, amikor beállítja ezeket az eszközöket. Ez ez egy nagy lépés szerintem
+
+– mindenképpen.
+
+– És amúgy nektek van valami webshopotok, ahol elérhetőek ezek a termékek?
+
+– Lesz hamarosan. Igen.
+
+– Ühüm. Ott se lesz egy széles kínálat, tehát nem a kereskedelmi oldalára megyünk rá.
+
+– Ühüm.
+
+– Valószínűleg csak a legfontosabb és legalapvetőbb eszközöket fogjuk majd árulni. És az is valószínűleg inkább azt, ami nehezebben beszerezhető, tehát import termék Európában is, amit Európában meg lehet, azt már szerintem javasoljuk, hogy a közvetlenül a gyártótól nyugodtan versetolják meg, mert egyszerű, gyorsan kezelhető. Például Coldcard ugye az kanadai, úgyhogy ott reseller pozíciónk van már meg állapodásunk velük, úgyhogy valószínűleg azokat majd mi árulni fogjuk.
+
+Az összes terméküket egy megbízható, jó Bitcoin cégről van szó. Tehát nem mindent szeretnénk árulni, sőt csak azt, ami megbízható, csak azt, ami Bitcoin stabil, ajánljuk, használjuk, segíteni akarunk. Tényleg én a kereskedelmi részében nem üzleti oldalát látom ennek, hanem inkább inkább egy ilyen szükséges kiegészítőt, ami ahhoz kell, hogy társadalom jobban használja a bitcoint.
+
+– Ja, ilyen megtámogató, nem? Tehát, hogy akkor erről beszéltünk, és hogy amúgy itt van, de mehetsz a
+
+– saját magad útján is.
+
+– Ja, ezek fontos dolgok. Te, hogy látod, nyilván látsz egy te is ebbe egy ilyen lépcsőzetességet, ugye az első, második és harmadik konferenciában, vagy hát nem tudom. És szerinted a negyediket azt milyen szintre kell emelni? Arról beszéltünk ugye a végén, hogy workshopos időt fogunk majd kialakítani és kiscsoportos egy öt fős csoportokban néhány szakértő, jelentkező szakértő kolléga fog majd segíteni különböző témákban az embereknek.
+
+Gondolom a hardberbet lesz a legfontosabb, ami kézenfekvő akár, vagy egy vásárolja bitcoint, hogyan kezeljem a tárcákat. Valószínűleg ezek lesznek a legaktuálisabb kérdések. Úgy gondolom, azzal még magasabb szintet tudjuk emelni azt az értéket, amit eddig is adtunk. Behoznánk a generációkban, kiegészítenénk egy kicsit a képet az idősebb, a tapasztaltabb generációval is. Ugye a fiatalokot most láthattuk színpadon, és az mindig szerintem nagyon ügyítő és aranyosak, és nagyon szuperül mondják az élményeiket, illetve a tapasztalataikat a Bitcoinról.
+
+Úgyhogy reméljük, hogy őket még ki is tudjuk egész más fiatalokra is. Esetleg akik addig úgy gondolják, hogy Simhadra szeretnének jönni és szeretnének beszélni a saját útjukról. De a tapasztalat generációt is nagyon jó volt hallgatni. Az első kezdő Bitcoin körben. Arite ott volt, tehát antite is. Ott a 70 pluszosok is között is volt olyan Bitcoin maxi, hogy öröm volt hallgatni és hogy öröm volt azt hallgatni, hogy mennyire érti és mennyire ügyesen csinálják.
+
+Ez nem kfüggő, hanem ez valahol érettség is, ki mikor üt erre arra a szintre. És ezért az, hogy a gyerekeinket már úgy tudjuk nevelni, hogy tudják, hogy mi a Bitcoin, gondoljátok, az mekkora előny, mennyi stabilitást tud nekik adni. Ezenkívül mi szeretnénk beemelni, promóálni azokat a vállalkozásokat, akik bitcoint fogadnak el, és szeretnénk ilyen bejelentéseket is tenni, hogyha lehet akkor a cégvezető eljönne pár percbe, elmondaná mondjuk azt, hogy miért fogadták el, hogyan fogadták el, mi volt a fogadtatás.
+
+Ugye most is volt egy ilyen bejelentés. északetmagyarországi telekomszolgáltató jelezte, hogy bitcoinnal lehet már fizetni a szolgáltatásaikért online. Ő egyébként Nyíregyháború környékén szolgáltat internetet és tévét.
+
+– A Giganet, akkor már is bemutat.
+
+– Giganet abszolút, csak nem akartam rosszul mondani a nevüket, de
+
+– akkor te emlékszel rájuk.
+
+– Ühüm.
+
+– Zolia cégvezető, tulajdonos jó barátom, azt mondhatom, csak a cégnevüket nem annyira szoktam forgatni. Én nem azon a környéken rollolok, hogyha egy kicsit megfoghatom a fiatalokat ezzel a slanggel. Én úgy gondolom, egyre egyre szélesebb körben tudunk majd egyre több ifarágot felsorok htva bemutatni olyan cégeket, akik bitcoint fognak tudni el elfogadni, vagy szeretnének elfogadni. Nyilván ezt mi vállalkozás szinten is támogatni fogjuk majd januártól, úgyhogy erre készülünk, hogy intézményesített keretek között tudjuk majd orange pillni, sárga bogyózni a vállalkozásokat, hogy bitcoinra szoktassuk őket.
+
+Jöttek érdeklődések egyébként a környezetemből olyan vállalkozóktól, akik mondjuk országos lefedettségűek, csak hallottak a konferenciáról is, hogy milyen volt. Én mondtam, hogy hát miért nem akarszint elfogadni, milyen menő? És hát nyitottak rá, úgyhogy ezt egy picit majd jobban meg fogjuk támogatni. A konferencián ilyen hasonló újdonságokkal készülünk majd tavasszal is, és a szervezés azt mindenképpen január elején elkezd, úgyhogy január végétől hivatalos program is lesz majd.
+
+Mindig igyekszünk egy kicsit előbb programot meg konfliktumokat adni. Eddig ugye egy évre kezdtük ezt az egészet, és ez a harmadik alkalom volt. Mindig els adult minket az üzleti év, de ezért is kell intézményesítenem ezt a Bitcoin Journeynek a támogatását, tehát ezt az út támogatását, hogy legyen olyan dedikált kolléga, aki csak ez a feladata, hogy ezt támogassa. Úgyhogy ezen az úton vagyunk mi is, mi is az érettség egy bizonyos útján, fokán járunk, nem a tetején még.
+
+És ez csak egyre jobb lesz. És úgy gondolom, ahogy szerintem ti is, hogy erről a vonatról a Bitcoin tud minket lesegíteni, és a Bitcoin szigetére tud magunkat kidobni. Eh ez a vonat viszont a falnak fog menni így is, úgy is, úgyhogy
+
+– nincs más út.
+
+– A fiat vonat. Így be.
+
+– Ja. Még egy dolog eszembe jutott, hogy te mennyire látod így, hogy mennyire ér érte el ez a konferencia azt a közeget, akinek ez szól. Nyilván egy csomó ember nem tudott eljönni. Nem tudom, hogy az látszott-e olyanok. Mondjuk a regisztráció ugye az az előzetesen megvolt.
+
+– Én valamivel több embert vártam. Sok ingyenes regisztrációs lapot hevert még szerintem vasárnap délelőtt is vártuk, hogy eszek felkapják az emberek. Nem tudtak eljönni. Nyilván mindenkinek lehet ilyen okava. Nekem többen jelezték, hogy eljöttek volna, de nagyon sűrű az októberi szezon konferenciák tekintetében. Úgyhogy jövőre mindenkit indokolt, hogy átgondoljuk esetleg november közepére tegyük át ezt a konferenciát, akkor kevesebb ilyen esemény van.
+
+Nekem az a tapasztalatom.
+
+– Én is nem olyan régen néhány éve kezdtem el így aktívabban egyéb konferenciákra is járni, nem csak Bitcoin, hanem minden más szakma. És hát beint én is még fiatal vagyok ebbe az egészbe, de most már azt láttam ennyi év tapasztalta, hogy a november az mindig lassabb. Az október az teljesen tüziáték. Egyszerre három konferencia is ment a miénkkel együtt, amire meghívtak. Úgyhogy ezért is gondolom, hogy mások is máshova voltak elköteleződve.
+
+De semmi gond, hát majd jönnek a következőre az emberek. Illetve hát az idő, az idő mindig megmutatja azt, hogy ez ami értékes és mi az, ami maradandó. És én úgy gondolom, hogy egy nagyságrenddel több ember az, aki ismeri azt, hogy mi a Bitcoin általunk, a HUSZONEGY által és akár általam is, és ők idő előbb utóbb beforognak majd hozzánk is élőbe. Fogjuk fogunk velük találkozni is ezekkel az emberekkel. Most ne felejtsétek el, hogy mindenki akkor kezdi el felfedezni, hogy mi a bitcoin, mikor szüksége van rá.
+
+Amikor úgy érzik az emberek, hogy szükségük van rá, akkor a három-négy konkurens konferencia közül, ami szakmai vagy életfitel bármilyen konferencia, akkor szerintem majd a bitcoint fogják választani, mikor az nekik szükséget tesz.
+
+– Ja. Ja.
+
+– Mi senkit nem akarunk rábeszélni, senkinek nem akarunk könyörögni. Nagyon örültem és megköszöntem a barátaimnak, akik eljöttek egyébként messzedről is venéztek. Mindenki nagyon jól érezte magát, és mindenki gratulált egyébként a helyhez meg a közösséghez. Senki nem gondolta, hogy ilyen jó a Bitcoin közösség, és mindenkinek leesett az állla, hogy mennyire kedves és értelmes emberek alkotják ezt a közeget, de szerintem önmagában már egy hívószó.
+
+Ennek idő kell úgy, ahogy a podcastnek is nagyon szépen beindult a podcast is, úgy látom
+
+– szépen megyege.
+
+– Ez a proof of work, tehát a
+
+– Ja, igen.
+
+– Történelmet meg kell írni egyszer. A saját történeted írod a saját tetteid által, és azt csak a befektetett munkával tudod megírni. És mi most történelmet írunk, gondolom az a következő 5-6 év 2030-ig. Ez mind a történelmi alapok lesznek, amikor visszatekintenek az unokáink, akkor majd el tudjuk nekik mondani, hogy mi ott voltunk, én elmondtam, én ott voltam és segítettem másoknak. Ez olyan, mint a 1900-as évek elején, mikor elindult a nagy boom, gazdasági boom globalizáció, és mi ott voltunk az első hajón, ami Amerikába ment, és mi áthajóztunk a szabadság földjére.
+
+Én ilyenek látom a bitpoint. meg az útunkat is
+
+– mindenképpen úttörés már így a pozitív értelmezésében.
+
+– Ma hallgattam a Jack Mallers-nek a legújabb podcast epizódját, ami ugye magyar idő szerint tegnap éjszaka volt, és pont ezt a párhuzamot ő is meghúzta, hogy most ilyesmi zajlik, csak most már ez a költözködés az nem kontinensről kontinensre van, hanem ugye a a hanyatló pénzügyi rendszerből, a az új pénzügyi rendszerbe. Most már az 1900-as 1900-as évek elejéhez képest ugye már nincsen nincsen kifogás, hogy ott kell hagyjad a családot, hogy emigrálni akarsz, vagy kalandot akarsz keresni, vagy biztonságot keresni, hanem most már mindig mindenkinek a saját döntése, hogy átmegy-e a Bitcoin útjára.
+
+És ehhez magyar nyelvű segítséget is adunk a konferenciának, ugye a ti segítségetekkel, meg ahogy elmondjuk a tömegeknek. Úgyhogy tényleg mindenkinek már csak a saját szuverén döntésén múlik, hogy kilép a Fiat vonatról, ami a falnösszágú.
+
+– Hát ja, most már megvan hozzá minden, illetve hát egyre több minden. És szerintem tényleg nagyon sokan így ráismertek a betegségekre, hogy hogy hogy mit okoz a FIAT. Tényleg a a amerre nézek, mindenhol így jön szembe. De most már már nem csak így a közösségbe, hanem így egyre többen mondják. Tehát olyan emberek, akik így nem bitcoinerek, de azok is így kezdik felismerni, hogy figyelj, itt valami valami tényleg nagyon rossz, mert nem kéne, hogy így működjön a világ, tehát minden így drágul.
+
+És akkor mindig feldobom nekik a kérdést, hogy hogy valószínűleg a pénz a rossz, nem? Hogy gondolkodtál már ezen? Tudod, ez még nem orilling talán nem ilyen nagyon durva, csak könyvek fogytak a legjobban. Ennek örültem. 30 könyvet vettek tőlünk a résztvevők vagy
+
+– szuper.
+
+– Főleg a Tóth Robinak a magyar nyelvű Bitcoin könyvét. Úgyhogy Robi ezúton is köszönjük szépen a kontribúciódat az ökoszisztémához, mert olyan értek közérthetően leírtad a Bitcoinról alkotott gondolataidat, és soknak ez értékes és el is vitték magukkal haza.
+
+– Jó, hátha legközelebb el is tud jönni.
+
+– Igen, jó lenne.
+
+– El el szerintem el. Most már összehozzuk valahogy, ugye, mert mert az a márciusir az Atlantisra is akart jönni, akkor sem tudott. Reméljük, most bele fog neki férni.
+
+– Most kitalálunk valami trükköt, hogy ne ne bírja kihagyni. Igen,
+
+– meg hát alakultak még egyéb Bitcoin maxik is egyébként, akik nincsenek még HUSZONEGY tagok se, úgyhogy mert őket is kicsit számba vesszük szerintem közösen.
+
+– Egyébként jó lenne az ilyen emberektől is hallani valamit, mert rengeteg mondan valójuk lehet szerintem. Tehát én nem tudom, én ezt a három napot úgy éreztem, hogy nagyon kevés. Úgyhogy most, hogy így felhoztad ezt a táborötletet, ezt abszolút én emellett vagyok. A végén meg majd egy bentlakásos
+
+– komuna
+
+– templom lesz a hegy tetején és sose jövünk sose jövünk ki egy évig
+
+– igen
+
+– de tényleg tehát hogy nekem például felüdülés volt hallgatni az előadásokat mert annyira jó volt. Tehát így olyan boostot adott Katáé meg nagyon főleg az tök jó volt meg azért a a mindegyik meg látszik, hogy mindegyik így finomodik, úgyhogy ezek ezek jó dolgok. Az elején tartunk, azért ne felejtsétek el kedves közönség sem, hogy egy másfél éve léptünk egyáltalán nagy közönség elé is ugye podcast két éve, nem is tudom mikor volt az évforduló, tehát ezt gyakorolni kell, és nem vagyunk profi előadók, mert nem a színművészetire jöztük, hanem a meggyőződésünket adjuk el.
+
+A akartam mondani, hogy mindenki ilyen tök béna kábé, vagy hát nyilván nem tudom magam nevébe, de hogy amatőrök, tehát ha valami sikerül, azt nem biztos, hogy tudjuk újra produkálni, de az üzenet szerintem így hitelessé teszi meg azt, hogy ott vagyunk és tényleg így beszélünk róla kínjaink ellenére is. Itt csak tényleg visszatérve ehhez, hogy én én nagyon szívesen látnám azokat az új emberkéket, mert ugye a a Bitcoin kör alkalmával mindenkinek volt lehetősége egy-két perces megnyilatkozásra magáról, amit fontosnak tart, de az ember ilyenkor szerintem nem mindent tud így jól elővarázsolni abból a gondolatalmazból, ami az éppen a fejében játszódik, mert csak magamból kiindulva így kapkodom össze a szavakat, hogy akkor ebből tudok mondatot alkotni és jó lesz a kimenet is, de nagyon-nagyon sok olyan emberke volt, akitől sokkal többet lehetne tanulni, meg hallani, hogy ő miért van itt, mi az, ami ami bekapcsolta nála azt, hogy itt a helye, hogy és és ezek a kis emberkék mindig hozzáadnak az egészhez, sokkal több lesz így.
+
+– Igen, mert valós tapasztalatot hoznak be, tehát olyan olyan gondolatokat és olyan történéseket, amiket amiket ők átéltek és hitelesen tudják elmondani. Nemmondhatjuk mi, hogy mire lehet használni a bitcoint, de igazából mindenkinek a saját történetén keresztül tud adni egy valós behasználási módot. Olyan emberi történeteket hallgattunk, hallottunk csak a bemutatkozás közben is, ami önmagában egy podcastet megérne egyébként.
+
+– Igen. Úgyhogy ebben fúha én nekem annyi ötletem lett, úgyhogy gondoltam rá egyik pillanatban még talán csütörtök este, hogy jó lenne nyitni egy jegyzetlapot, mert mert ezt biztos, hogy nem fogom megjegyezni. És ezúton is köszi Árpi, hogy te meg oda is toltad már ugye azt a a CBDC weboldalt a a HUSZONEGY csoportba a címét, mert azt azt például nem írtam föl.
+
+– Ühüm. Hát én meg ott ültem a közönségben, és amikor valaki azt mondta, hogy majd betesszük a Telegramra, akkor
+
+– akkor nyomtad a jegyzet.
+
+– Nagyon profi, nagyon profi volt.
+
+– Ja. Úgyhogy én is írtam egy listát. Hát én megmondom őszintén, ugye mivel most még csak ked van, és gyakorlatilag ked van. Igen, kedd, azt se tudom már milyen nap, hogy én is nemrég jöttem haza és szerintem legalábbis részemről így meg így el tudom azt mondani, hogy hogy ezekkel a kérdésekkel, amik szembejtek ott, foglalkoznunk kell majd, és és szerintem a podcast keretein belül lesz a legjobb alkalmára első választ adni,
+
+– ugye, hiszen az egy ilyen folyamatos dolog. Most a sorrendisége ennek ilyen véletlenszerű lesz, úgyhogy azoktól most elnézést kérek így előre, akik úgy érzik, hogy az ő kérdésük fontosabb. Itt minden kérdés fontos, haladunk majd sorba. Én tényleg fölírtam egy tök hosszú listát, nagyon sok emberrel találkoztam. Szerintem őket is meg fogjuk keresni, hogy nyilatkozzanak meg ezekről itt ezen a platformon, és így tudunk növekedni, vinni a vinni az igét.
+
+– Szuper. Én is most átadtam a mikrofont. egy srácnak, Martinnak, aki majd jön podcastolni, majd kitaláljuk, hogy melyik héten, de a lényeg az, hogy megbeszéltük, hogy hogy kölcsön kap egy olyan mikrofont, ami ami jobb minőségű, mint az ami a az ő gépébe van beépítve, és akkor majd ő is bemutatkodik a közösségnek.
+
+– A narancs mikrofon túra.
+
+– Igen, az így szokott néha vándorolni. Hát volt egy srác egyébként, aki kör végén mondta, hogy ő először van Magyarországon közösségben, és ő például Metaplanet-nek fejlesztettek például a Proof of Reserves alkalmazást.
+
+– Wow.
+
+– Ha most ezt most ezt hallod, akkor majd szerintem jelentkez a HUSZONEGY-ből a srácok már egy podcast mindenképpen megérnek.
+
+– Ez így. De Ja, ez tök jó. Tényleg olyan olyan megdöbbentő dolgok vannak, nem? Tehát ott szembesülsz, hogy azért milyen mély itt a tudás. már hogy a közösségen belül
+
+– mennyire tág mennyi mennyi
+
+– pontjára jöttünk a világnak hogy tehát szóval annyi értékes ember volt aki már ugye tudta hogy mi a bitcoin és alapvetően kapcsolódni jött a többiekhez és szerintem keves magyar magyar társadalom és egyébként Miskolc meg a régió sem tudta felmérni azt hogy mekkora tudás jött ide és hogy ez mekkora megtiszteltetés példá akár a Miskolcnak is vagy a régiónak is hogy egy ilyen rendezvény ilyen emberek ellátogattak mert nem sztárok voltak ezek a srácok, hanem hanem egyszerű dolgos emberek, de olyan tapasztalattal, hogy tehát szóval megtiszteltetés volt tényleg, hogy itt voltak a köreinkben, meg eleve mindenki ott ugye eljött.
+
+Sajnos ez úton is el tudom mondani azt, hogy Miskolc nem annyira foglalkozott velünk. Én nagyon sajnálom. Akkor küldtünk nekik egyébként meghívót is. Remélem, hogy legközelebb azért picit jobban kezelik ezt az eseményt, mert mert megérdemeli.
+
+– Üüm de a helyiek már, hogy így a helyi önkormányzat
+
+– nem kaptunk nem kaptunk semmilyen nyilvánosságot vagy vagy felkérést, vagy nem is tiszteltek meg a jelenlétükkel, ami nem akkora baj, csak
+
+– szerintem ez úgy utólag visszanézve azért ez ez kár egy kihagyott lehetőség volt nekik is szerintem mindenképp. meg a helyieknek, mert azért nem volt túl sok helyi. Tehát szerintem egy olyan 40 főnél több nem volt a 150-ből.
+
+– Azért az ne legyél elégedet.
+
+– Az is valami. Ühüm. De ezek szerint a Hajdú Szoboszlói az jobb volt legutóbb.
+
+– Ott ott szerintem két Hajdú Szobosztói volt.
+
+– Ja, hát akkor
+
+– na
+
+– akkor fejlődő a tendencia.
+
+– Kiutatható. Nem, hát szoboszon vicces volt, mikor kijött a helyi tévő, hogy megkérdez egyik helyi résztvevőt, hogy neki hogy tetszik a konferencia, és nem találtok helyit.
+
+– Ühüm.
+
+– Mindegy, kenessetek már valakit gyorsan. Én voltam végül is, hogy valami helyi kötődésem van, meg hát releváns is voltam, de szóval ez ilyen. De egyébként ezt elmondtam másoknak is, hogy egyébként mikor voltunk a Bitcoin Atlantis-on Madeirán, ott is én azt gondoltam, hogy a nyakamukba akasztják majd a hulla hulla karikát és akkor izé táncot járnak, hogy itt a Bitcoin sziget és a izé másik sziget.
+
+– Senki nem vágta, hogy miről van szó. Tehát meg egy szinte egy Miskolc méretű sziget és a taxis azt se tudta, hogy miről van szó. Tehát az a Bitcoin események még mindig nem olyan mainstreamek, mint egy foci rendezvény és sportrendezvény egy Forma 1. Tehát ezér várni kell egy kicsit.
+
+– Hát igen, meg azért szerintem így ilyen médiahát szélbe is van, tehát azért ez szerintem így elég shadow bannelt community most ilyen szép magyar mondatba elmond.
+
+– De nem baj.
+
+– Tehát figyelj, növünk. Én nem vágyok semmilyen nagy tömegre. Én Én igazából eljövünk, elmondjuk, hogy mi van. Én szerintem érünk annyit, hogy majd az kiforrja magát, meg vagy a valóság úgy is elbírál minket. Megcsináljuk szépen azt, ami kell. Podcasteltek be, ahogy ahogy kell. Szuperül csináljátok, rengeteg értéket adtok másoknak. És ezt vissza is jelzik nekünk ugye most a konferencia alkalmával is rengetegen mondták, 700 több mint 700 tagunk van egyébként.
+
+Tehát ez már szerintem nemzetközileg is egy értelmezhető HUSZONEGY közösség. És a egységben az erő, tehát minél több tagink lesz, annál annál erősebb lesz a bit közösség mó.
+
+– Igen, de ha jól tudom, ti is készültek azért így a konferenciát összefoglaló anyagokkal, ugye, mert szokott kijönni
+
+– természetesen. Igen,
+
+– jönnek majd az előadások. Most a konferenciatechnológia is a miénk volt, nem külső szolgáltatója. Nagyon izgultunk, de szerintem a srácok teljesen jól tették a dolgukat, jó kedvvel, munkabírással.
+
+– Igen.
+
+– Váratlan helyzeteket is megták. Így van. Így van. Audi kapitány és a többiek.
+
+– Jó volt.
+
+– Igen, jó volt. Ügyesek voltak és a videók is fognak jönni. A hang is rendben volt. Gergő megnyitatott minket hétfőn, hogy oké srácok, ha néztem a hangot, rendben van. Mondom,
+
+– föl is vették a hangot.
+
+– Igen, meg megnyugodtam. Igen.
+
+– Talán majd Lőrinc is eljön megint meg.
+
+– Hát igen, igen, igen. Most is jött volna, csak nem fért be neki időbe. Ezt már jelezte nekem, de szerintem tavaszal is újra fogjuk majd látni. És szerintem TikTok sorok is lesznek, tehát short videók is lesznek ezekből az előadásokból. a a legjobb zvonatokat, említéseket, ezeket ki fogják majd ragadni egy-egy perces videóba, és azok is lesznek majd promótálva, úgyhogy több fórumon össze lesz majd ez foglalva és publikálva.
+
+– Meg ott mintha készültek volna a helyszínen ilyen mini interjúk, azzal mi a terv? Azt lehet tudni?
+
+– Igen, igen, persze, azok is közzé lesznek téve. Így van. Sorcokként illetve hogy összej összevágjuk majd az anyagokat. Szerintem jó lenne egy igen, egy ilyen összefoglalós anyag, ilyen másfél órás esetleg, ami legjobb részeket elemzi majd Gergő ezúton is. Akkor légys szíves
+
+– majd a Netflixből.
+
+– Hát hátha lesz rá kapacitás, mi?
+
+– Hát biztos lesz. Persze.
+
+– Ja,
+
+– viszki. Jó az így. Neked vagy nektek melyik előadások tetszettek legjobban a így ezekből? Mondjuk így nehéz kiemelni egyet, kettőt, meg hát nyilván az ember így elfogult tud lenni. Nekem egyformán jó volt. Szerintem anti tér az nagyon szuper volt. Nem lehetett látni, hogy izgulsz, de annyira steady folyamatos hanglejtéssel nyomott, hogy srácok csak attól féltek, hogy annyira lent tartottad a mikrofont, hogy a koroget a hasad, akkor azt is hallottuk volna, mert olyan érzékelységű volt.
+
+De
+
+– de hát de a többiek is jók voltak. Ugye RP-nek és a Firefish bemutatója is azért jó volt. Először hallhatunk ilyen jellegű szolgáltatási színpadon. Kata nagyon megmozgatott mindenkit.
+
+– Ühüm. Ja, igen.
+
+– Úgyhogy jó volt. Én én meg igazából fáradt voltam picit. Majd legközelebb kevesebb kevesebbet vállalok, mert hét előadás volt és az csak felkészülni és
+
+– az hát annyi kell. Akkor kell.
+
+– De szerintem tök jól nyomtad. Én azzal lepődtem meg, hogy ugye még a panelbeszélgetésen is te voltál a moderátor, és hogy az is az is tök jót. Meg ugye, hogy amikor gyerekek a színpadon voltak, akkor is tehát azért elég elég sok kanócot tartottál a tűzbe.
+
+– Hát megmondom őszintén, többet várok majd magamtól felkészültségbe, mert nagy része impro volt. Hát de de azt jól csinálod. Ez így
+
+– de azt de de igazából Bitcoinról mindig jó beszélni és és vannak érdekes témák, úgyhogy bíztam benne, mikor a panelhoz is összeültünk, hogy lesz olyan téma, amit amit az elején megbeszéltünk előtte pár perccel, és azt tök jó beszélgetés alakult ki belől és informális is volt. Volt
+
+– persze. Hát olyan emberek vagyunk, mármint olyan a közösség olyan olyan emberekből áll, akivel hogyha elkezdesz beszélni, akkor mindig van valami új téma. Főleg, hogyha Nara is ugye teljesen másik világból származik, úgymond máshol lakik, ott azért
+
+– a helyi kézzel fogható információi, illetve a tapasztalata az az nekem nagyon nagyon érdekes. Szerintem másoknak is.
+
+– Ja, az is jó. Meg az a jogi vonal is, amit a jogászat hozott be, az is nagyon jó volt. Remélem, ez majd most egy olyan panelbeszélgetés lesz, amiből szintén lesz felvétel, mert azzem az eddigiekből valami miatt nem sikerült.
+
+– De ebből lesz,
+
+– vagy mindig volt olyan tag, ugye, akit nem akartunk, hogy szerepeljen a videón, meg ugye mostaniban is, de
+
+– most is lesz, de őt kültöttük most a szélén.
+
+– Ah, meg lehet azt oldani, hogy ne látszódjon. Meg persze, persze. Megold,
+
+– de amúgy meg maga a beszélgetés az szerintem nagyon nagyon értékes gondolatokat tartalmazott.
+
+– Családokat is jó volt látni egyébként, mennyi gyerek volt, még többen jöttek családdal. Olyan is jött egyébként családdal, aki még teljesen új volt. Nagyom ez meglepő volt. Voltak páran például Fire Communityból, közösségből. Ugye ez egy ilyen befektetői csoport, aki igazából arra törekszik, hogy félre tudjon tenni az idősebb kore korukra, tehát ilyen anyagi függetlenséget támogató csoport. És én oda jelentkeztem kábé egy fél éve a Facebook csoportba, be is csomag fogadtak.
+
+volt, amikor azért már majdnem kiátkoztak, mert megemlítettem, hogy a Bitcoin az mennyit ment az elmúlt egy év, és azüm
+
+– minden mindenkinek tetszett, de volt, akinek tetszett, és én ezért is szoktam egyébként beleállni ezekbe a témákba, és nem felvéve az aroganciát,
+
+– hát azt nem szoktuk
+
+– folyamatosan, szisztematikusan válaszoltam a kérdésekre, és nem felvéve a boxkesztyűt, inkább csak a válaszokat kiegyenesítve és a mondandóat elmondva, több olyan ember jött, aki abból a közösségből volt, és tök jó abszolút. Persze, persze. A helyi miskolci közösségből is volt egy hölgy. Többen nem tudtak eljönni. Volt, aki azt írta például a csoportban, hogy őt hát őt nem érintette meg a Bitcoin így előzetesen, úgyhogy ő el se jön.
+
+Mindenkinek eljön az ideje szerintem, amikor úgy gondolja, hogy kell egy olyan eszköz, ami ami államoktól és vállalatoktól független, mert ezt csak a Bitcoin tudja adni. Meg úgy gondolom az arany sem, mert rengetegen rengeteg embernek van aranya. ETF-ben vesz aranyat arany aranylapkával, amit nem tud igazából használni. A se tudja, hogy arany-e vagy nem, vagy a Bitcoinnak nagyon erős használati értéke van, és ez szerintem egy kulcsmondat is volt, amit mostanában szoktam mondogatni.
+
+A bitcoin nem azért értékes, mert felment az ára, vagy hogy 110000 dollár, hanem azért, mert amilyen tulajdonságai vannak, amilyen hálózat és emberek csoport keresi ezt, amilyen az adaptációja annyira értékes. És még az adoptáció legelején járunk, de már látom azt a jelet egyébként, amikor már az ördi adopterek elfogynak. Tehát azok az emberek, akik technik technikailag innovatívabbak, akik kockák már kockákon túljutott már ez a dolog.
+
+Ugye látjuk bőven, hogy már kevés az informatikai ismeret, és nekünk ezt a űrt gapet kell be befor befoltoznunk, hogy az emberek nyelvére, köznyelvére érthetően le tudjuk fordítani a bitcoint, és hogy meg tudjuk fogalmazni azt, hogy mi ez az egész, hogy ők is értsék és tudják használni.
+
+– Hát igen, itt mindenki kiveszi a részét a saját professzionalizmusában, vagy nem abban, de ami éppen így testhez áll neki, amivel úgy érzi, hogy hozzá tud járulni. És szerintem a jelenlét az is az elején, aztán úgyis megtalálod azt, hogy majd elmondod a barátodnak meg annak meg a másiknak, és akkor kialakul, hogy mi lesz. egyébként szerintem a legjobb ebben az, amikor így ugye egyrészt beszédtéma, másrészt pedig ez a beszédtéma így publikus lesz, tehát ilyen kisebb körök tudnak kialakulni és kisebb találkozók, aminek a témája ez, mert ugye ez most Miskolcon volt, és azért jöttek PSről meg innen-onnan messziről még mintből is.
+
+De szerintem azért sok embernek volt gond az is, hogy hogy távolság, illetve hogy munkanap, munkanap szabadnap volt a felállás. De ugye amikor ennedik ilyen kis Bitcoin konferencia után valaki hazamegy a szülővárosába, és ott csinál egy meetupot, akkor ezt tovább tudja vinni, mert ugye ez egy decentralizált dolog, tehát az a jó, minél több helyen beszélgetünk róla, mert akkor jön elő az, hogy mi foglalkoztatja az embert, mit tart veszélyesnek benne, arra kaphat választ, vagy találhat hibát, mert ugye azért sok ember nemát van ez a mém, hogy most jöttem a Bitcoinba, azért most szeretném megjavítani.
+
+Szóval ez mindig olyan, hogy a hogy az ego azért harcol, hogy hogy azért már mindenkinek igaza legyen, aki ezt csinálja. akkor biztos találok benne valami hibát, de hogy ezek ezek is kellenek bele szerintem, mert minden ember más nézőpontból tudja vizsgálni és és lehet, hogy éppen mond valamit, amire eddig nem gondolt az a több 100 vagy több 10 millió ember, aki használja. Có, hogy mondod egyébként a decentralizáltságot és az országos kis pontokat, akik meetupokon összegyűlnek.
+
+Én felsejnen látom azt a jövőt, azt az elég egészen közeli jövőt szerintem egy-két éven belül már, amikor egy kicsit elcsépelt szó lett, de ez a polgári körök alakulnak ki, ugyanogy a üzleti körök is üzleti körök is kialakulnak. És gondold el, hogy azért a aki a bitcoint érti vagy használja, az nem azt mondom, hogy rossz ember nem lehet, de az már megugrott egy bizonyos mentális kérdést, amikor lehet, hogy azt a attól a vállalkozótól vennék anyagot, aki Bitcoinban elfogad fizetést.
+
+Lehet, hogy azt az embert alkalmaznám, aki bitcoinban szívesen kapna fizetést. Lehet, hogy ott költeném a pénzemet, akár árcikkeket véve is, aki bitcoint elfogad. És ez az összetartás szerintem ez néhány éven belül ez már egy jelentős dolog lehet. Úgyhogy mindenkit szeretettel várunk, aki vállalkozóként kapcsolódna ehhez, mert határozott meggyőződésem az, hogy ezt nem a vásárlóktól kell kezdeni a Bitcoin adaptációt, hanem a vállalkozóktól bármennyire.
+
+És a a Bitcoin egy szabadság peer topeer cash system, ugye egy olyan készpénzfizetési rendszer, ami az embereknek vt létre. Igen, de viszont az árucsere jelentős része az nem az emberek között, magánszemélyek között történik, hanem vállalkozók és magánszemélyek között. És a vállalkozóknak szerintem lépniük kell abban, hogy elfogadjon a bitcoint. Itt a lehetőség még, és szerintem hamarosan kell lesz indítanunk ilyen kis köröket mindegyik nagyvárosban.
+
+Mindenki, aki esetleg ezt fel akarja karolni, vagy részt akar benne venni bitcoinként, az szerintem a HUSZONEGY-ben kiváló csomópontot talál. És itt szerintem hamarosan lesz ilyen Bitcoin vállalkozó klubja is, ahol egymás között is tudjuk promótálni a szolgáltatásainkat, és hogy ha mindenki bitcoinnal fog kereskedni, akkor ez egy egészségesebb gazdaságot tud majd eredményezni valamikor a távoli jövőben. Viszont még most előnyt jelenthet akár.
+
+Igen, erre neked is van egy előadásod, ami ugye már itt többedik alkalommal volt, ez a Hogyan fogadjunk el Bitcoint, és annak egyik előnyeként jön ez, hogy a versenyelőny megmutatkozhat abban, hogy egy olyan gondolkodó réteget megtalál a vásárlói körbe vagy igénybe vevői körbe, aki ugye egyre inkább megengedhet magának egy elkölthetőbb jövedelmet,
+
+– és ugye a Bitcoin az nem egy nem egy Lyoness kártya. vagy egy bármilyen más klubkártya, amivel valaki megint valami nagyon sokat akar keresni, hanem ez a Bitcoin, az egy natív natív fizetőeszköz, a világ legerősebb pénze. És aki és aki ezt megérti, és aki támogatja a bitcoint, az az mondom egy körrel szerintem magasabb szinten van, mint mint más vállalkozó a megértésben. És hát egymást tudjuk segíteni.
+
+Szerintem ez szuper. Itt megint winwin helyzetek, nyertes helyzetek alakulhatnak. Igen, bár sok esetben még szerintem ez ilyen bagatel vagy ilyen versenyhátránynak hat, mert egyszerűen annyira már úgy értem, hogy annyira így a a társadalomban így a Bitcoin az szerintem ilyen lassan ilyen meg negatív megítélés alá esik, vagy
+
+– úgy gondolod?
+
+– Igen, mert szerintem a média azért megtette a hatását. Tehát szerintem h
+
+– most csak egy példa jöttem haza és itt egy pár üléssorral előttem ült egy úr és kinyitotta az újságot és hú milyen haladó mondom végre visszatér valaki az újsághoz és kinyitotta azt a rohadt nagy A3-as lapot vagy A2-est és ott volt kriptocsaló kegyetlen módon áldozatául tették ezt az embert és lehúzták és és kegyetlenek voltak és figyelj az ilyen ember aki ilyeneket olvas Az ha meghallja, hogy Bitcoin, akkor az is csak arra, tehát érted, tehát hogy arra asszociál, hogy ez egy ilyen kör, aki
+
+– én a vállalkozók között azt látom, hogy ez nincs meg.
+
+– Ühüm.
+
+– Tehát, hogy a közembereknél ez megvan, én ott sem tapasztalom, de tehát én már nagyon régen hallottam a kommentek szekción kívül, az interneten kívül, hogy valaki nagyon lecsalózta volna a bitcoint.
+
+– Ühüm.
+
+– Vállalkozóknál meg meg minimum egy jó tőzsdei eszköz, ami nagyon érdekes, nagyon újszerű. Nem tudják, hogy hogyan lépjenek bele, belerakják a lábukat, vagy nem, de már sokan egyébként vettek és belerakták a lábukat, nyilván ETF-ekben, meg bankszektoron keresztül. Én Én pozitívan látom ennek az író megítélését. Én nem én már nem félek. Tehát én nem én nem gondolom, hogy versenyhátrányt vagy megsz megítélést kapnák bárkitől azért, mert bitcoint promótájuk nincs céges szinten.
+
+– Ez tök jó hallani. És ami ahogy mondod is, ugye itt itt is most a konferencián volt egy pár emberke, aki aki vállalkozóként volt jelen, tehát már a bemutatkozásából kiderült, vagy pedig későbbi beszélgetések alkalmával. Ja, jó. Hát igen, persze, azért valóban ők a jelen kortermelői, ugye a szolgáltatás és árú előállítók, tehát valójában hogyha ők ezt elfogadják, akkor bejön pénzként, és akkor több értelmet nyer az, hogy ne csak hodlolj, tehát hogy ne csak tartsd, hanem költsd el olyan helyen, aki bitcoinért ad árút vagy szolgáltatást.
+
+És utána persze még tudod pótolni, hiszen még azért a vásárlás azért elérhető. Tehát milliónyi útja van a vásárlásnak, egy csomó módszer, full, minden teljesen tiszta és legális. Úgyhogy
+
+– a ciklusokat nézed egyébként szerintem az én azt láttam, hogy mikor csatlakoztak az emberek általában a bitcoinhoz. Ilyen 2017 volt a legnépszerűbb válasz és 2022, ugye ez a négy-5 éves ciklus. És ugye, hogyha valakinek sikerül tartogatni, hodölni HODL módba a bitcoinjait, akkor szerintem ez egy olyan legalább öt év, de inkább 10 év az, amikor ez a Bitcoin adoptáció odáig felfuthat, hogy akkor már aktívan fogják az emberek keresni, amikor a most már tartogattam 10 évig a bitcoinomat, most úgy gondolom ideje lenne költeni belőle, és akkor veszek egy házat, lakást, vagy vásárolok belőle.
+
+Tehát ez a ez a felkészülési időszak a szerintem a következő öt év 2030-ig és 2035-nél már biztos vagyok benne, hogy aktív kérdés lesz az, hogy hogyan hogy valaki elfogad bitcoint hiszem, az már egy az már egy fontos dolog lesz egy lakásadásvételnél biztosan, mert ugye az is egy jelentős vagyoni eszköz. Nyilván valaki nem egy sarűszeresnénak akar majd bitcoinnal vásárolni éppenséggel, vagy nem az lesz a legjellemzőbb, hanem nyilván a tartós cikkeknek a vásárlása.
+
+– Igen. És egész valószínű, hogy addig azért még lesz lesz elég nagy inflációja a forintnak meg az eurónak.
+
+– Hát konkrétan háromszoros szerintem ugye a 10% nem nagyon fog ez változni, ha csak nem gyorsabb gyorsulni fog az ütem. Tehát 10 év alatt két és fél háromszoros ára fognak nőni az árak.
+
+– Ühüm. Te gondold, ami most a lakásárak olyan 1 millió Ft a legalja, az 3 millió is.
+
+– Nem mondtál sokat egyébként.
+
+– 3 millió és azért 3 millió és olyan hat 6-7 millió Ft/ nm lesz a lakás, gondoltál. Bitcoin nézve viszont nem nőnek az árak, hanem csökkennek. Az is egy jó kérdés volt, megjegyzés még így a konferencia végén a körben, hogy legalábbis én szerintem nekiállok, kiszámolom majd, hogyha fiatal lennék, akkor hogyan tennék félre. Nyilván volt ez a 3000 Ft-os kísérletem, de de ezt egy kicsit majd realizálom, vagy jobban átgondolom még, és csinálok egy ilyen kis mini zsebkendő eszmefuttatást, hogy ha én most 22 éves lennék, vagy 20 éves lennék, akkor hogyan tennék félre lakásra?
+
+– Szemléltetni kell ezeket dolgokat minden esetben. Ja.
+
+– Jól van. Mi az, ami még így bennetek van? ebbe a témában
+
+– Árpi a család, hogy érezte magát?
+
+– Jól érezték magukat. Ugye a fiamt kifejezetten érdekelték az előadások, úgyhogy ő rengeteg előadáson benn volt és figyelt. Szóval, hogy mennyi mennyi amit megértett, az jó kérdés, de hát ugye ez mindenkinél teljesen egyéni, hogy mi az, amit elsőre meghal, megért, aztán mi az, amit legközelebb hozzárakódik valami és akkor megy mélyebbre. De a lényeg az, hogy őt őt nagyon érdekli és hát ugye még a színpadon is volt kicsit beszélni.
+
+– Tök jókat mond ő így a maga a konferencia aktív részét is élvezte. A lányokat kevésbé izgatja maga a Bitcoin, de amúgy jól érezték magukat, mert a társaság is jó volt, meg hát a szálloda is ugye a wellness részlegét élvezték szerintem a legjobban. Meg az is baromi jó, hogy ott a közelben van egy bópálya, és akkor ők odamentek még élvezkedni, meg az a park is gyönyörű ott a közelben.
+
+– Lesz még újdonságunk tényleg tavasszal mindenképpen lesz tematikus gyerekfelügyelet, tehát olyan gyerekmegőrző, ahol ahol dedikáltan egy óvónőt, vagy óvópedagógust, vagy pedig olyan tanárnőt fogunk kérni, aki vigyáz majd a gyerekekre és szórakoztatja őket. Úgyhogy a csalátosokat így bárabban tudjuk majd várni. Nagyon hasznos.
+
+– Igen. Anyuka is így majd le tud ülni, és akkor nem kell a gyerekre vigyázni, amíg apuka apukával együtt tudja nézni a Bitcoin előadásokat, és a gyerekk is jól érzik magukat, és felügyelve lesznek. Úgyhogy ez mindenképpen lesz a következő konferenciánk.
+
+– Talán az Atlantisban könnyebben is van erre helyi szín, nem? Ott kicsit
+
+– itt is meg tudjuk Piskorcosani, de az Atlantisban is így van.
+
+– It
+
+– így van.
+
+– Tök jó. Tegnap volt ugye a AWS amazon szervereknek a lehalása, de a Bitcoin hálózatot ugye nem érinti.
+
+– Mindig érdemes egyébként ilyenkor megnézni a nagy világban, amikor van ilyen kis felfordulás, hogy akkor a mit csinál a Bitcoin is, mit csinál minden más szolgáltatás, és hát a Bitcoin, mivel nem AWS szervereken, megy természetesen ezért ezért nem volt érintett.
+
+– Ja,
+
+– jó volt veletek egyébként. Jó volt titeket látni a hétvégén. Tényleg alapvetően két éve még nem is ismertük egymást, és most meg már igazából családtagként és nagyon közeli barát barátként üdvözöljük egymást mindig, és olyan nagy nem is kellen nagy köszönés, tudod, mint amikor valakit nem fogsz látni már öt év múlva, hanem alapvetően összefutunk majd úy folytatjuk
+
+– itt ott egyre repülőtéren Antival, Lőrinccel, vagy legközelebb egy meetupon, és hát ez szerintem ez annyira jó. Jó vol, jó, hogy megismertetek ezt srácok és örülök, hogy ehhez a közösséghez tudok tartozni. Köszönjük.
+
+– Aztán reméljük, hogy nem kell különösebben biztatni az újakat, de azért megtehetjük, hogy lelkesítjük arra, hogy minél aktívabban csatlakozzanak a közösséghez, akár a Telegramon keresztül, meg ugye szervezzük rendszeresen a budapesti meg a Miskolci meetupokat is. És igen, ahogy elhangzott már most tőletek, de erre is ráerősítenék, hogy ugye ahhoz, hogy több városban legyenek meetupok, akár rendszertelenül, akár rendszeresen, ahhoz meg keressük a az önként jelentkezőket, ugye, akik ezt elkezdik szervezni, mert hát ettől is decentralizált a működés a csoportnak is, hogy ugye azzok a dolgok vannak megcsinálva, amit magára vállal valaki, és akkor már az is lesz, de ugye egyikünknek sincs kapacitása arra, hogy olyan dolgokat csináljon, van amit amit valakik mások találnak ki, hogy ez is kéne meg az is kéne.
+
+Úgyhogy valaki érzi, hogy valamelyik városban kéne már egy bitcoin közösség, akkor vagy jelezzétek ezt a Telegram csoportban, vagy ha ismertek ott a helyszínen egy vagy akár több emberkét, akkor kezdjetek el ebbenyűzsagni, mert az tök jó, hogyha egyre több ilyen van.
+
+– Két ember az már meetup. És ha úgy gondoljátok egyébként, hogy valahol Budapesten vagy akár Budapesten ugye már szokott lenni bitup, de hogyha más városba is akartok Bitapot szervezni, én abszolút hajlandó vagyok rá, meg szerintem nyó néhány bitcoinel is, hogy arra az estére leugorjunk, és akkor kicsit ezzel is támogassuk a helyi közösséget és a gondolatvilágot. Egy egy-egy alkalommal természetesen nem mindig, mert arra nincs időnk, de én szívesen utazok egyébként az országban megismerni más embereket.
+
+A másik dolog még, amit el akartam mondani, mindenképpen a Nostr-t szerintem jobban támogassuk majd és promózzuk. Úgyhogy ezúton is kérek mindenkit, aki most itt minket hallgat, hogy
+
+– megztoljon
+
+– meg regisztráljon és kövessen minket, mert nem biztos, hogy mindig minden felületen elérhetőek leszünk a következő időszakban, mert hát a shadow banning és a és a és a random tiltások azok abszolút előtérben vannak. Hát ne nem is egy híres youtubert til jottak le az elmúlt fél évben, és és nekünk nincs 1 milliós meg 200-es elérésünk, hogy tudjunk szólni a YouTube helpesnek, hogy akkor állítsák vissza, hogyha sajnos a HUSZONEGY-et vagy akár a mi Bitcoin Miskolc oldalunkat letiltják, ott biztos, hogy az ott fog maradni egy jó darabig tiltás alatt.
+
+A Nostr-nél viszont nem tudnak minket letiltani. Nagyon fontosnak gondolom azt, hogy a pénzügyi hálózat mellett a kommunikációs hálózatot is fenn tudjuk tartani. A másik a pitchet lesz majd, hogyha alaposan teszteljük és használható lesz. De a Noster már most jó. Én magyar tartalmakkal töltöm fel folyamatosan. Egy darabig még hitáltam, hogy angolul is, vagy magyarul is, de igazából maradok a magyarnál, mert úgy gondolom itt van a legtöbb hozzáadott értékem.
+
+– Ühüm. Szuper,
+
+– hogy ott mindig elérhető leszek. Ott lesznek majd hamarosan a cégeink is, vállalkozásaink is, a Bitcoin Miskolc is, de én már ott vagyok és hát ti is elérhetőek vagyok a elérhetőak vagytok a Nostr-en. És hogy kérlek csatlakozzatok oda és regisztráltok. Semmiven nem kerül ingyenes. Úgyhogy ott tudtok minket biztosan követni.
+
+– Bizony.
+
+– Kövessétek be a HUSZONEGY csatornáját a Nostr-on, egy nagyon jó magyar nyelvű Nostr kliens, primal.hu. Hu. Ennek a linkjét betesszük a leírásba. Aki még nincs ott a Nostr-ön, ez egy jó kezdés hozzá. És itt a kezdéskombra kattintva létre hozni egy új fiókot és olyanokat követni, akiket szeretnénk. Iratkozzatok fel a YouTube csatornánkra is, sőt iratkozzatok fel a Bitcoin Miskolc YouTube csatornájára is, ahol hamarosan elkezdenek megjelenni a múlt hétvégi konferencia anyagai.
+
+A a négy csillagos Hotel Aurorában volt Miskolctapolcán, amelyik Bitcoin elfogadó és bitcoint tartalékoló szálloda is egyben, és nem utolsó sorban támogatja a podcastunkat hasonlóan a négycsillagos Hotel Atlantishoz, amelyik Hajdúszoboszlón van, és ahol a tavaszi a következő magyar Bitcoin konferencia lesz. És végezetül a Firefish is üzeni, hogy ne adjátok el a bitcoinotokat.
+
+– Köszönjük szépen Feri ezt a kiváló kis összefoglalót és várjuk, hogy mit posztolsz, mi jön ki majd erről a konferenciáról és majd azokról mindig beszámolunk. Köszönjük szépen a figyelmet nektek és találkozunk egy hét múlva ugyan. Sziasztok! Sziasztok!
+
+– Sziasztok!
+
+– Cool!


### PR DESCRIPTION
## Összefoglaló
- txt → md konverzió, 215 bekezdés, `>>` → `–` beszélőváltás
- **HUSZONEGY** egységesítés (11 helyen)
- Hotel Aurora, Hotel Atlantis, Miskolctapolca, Hajdúszoboszló
- **Nostr** javítások: Nosteren, Nosterr, Nostrán, Noseron → Nostr-en/on/ön
- Jack Mallers, Coldcard, Firefish, AWS, Proof of Reserves
- shadow banning, HODL, bear market, Lyoness kártya, Tóth Robi, Metaplanet, Bitcoin Atlantis

## Epizód
- **Cím:** Bitcoin Miskolc: közösség, szabadság, jövő
- **Résztvevők:** Anti, Feri, Árpi
- **Dátum:** 2025.10.24.